### PR TITLE
Fix default server issue

### DIFF
--- a/simmer.py
+++ b/simmer.py
@@ -398,4 +398,4 @@ def update_figure(selected_config,
 #### Start the App
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server(debug=True, port=8000, host='127.0.0.1')


### PR DESCRIPTION
I got this error:
`gaierror: [Errno 8] nodename nor servname provided`
when trying to start the app.  This PR fixes it (based on [this stackoverflow question](https://stackoverflow.com/questions/61002897/have-installed-dash-on-macos-but-gives-error-while-running-the-script/61421953#61421953))